### PR TITLE
Add settings menu for rules

### DIFF
--- a/application/copy_context.py
+++ b/application/copy_context.py
@@ -18,13 +18,24 @@ class CopyContextUseCase:  # noqa: D101 (public‑API docstring not mandatory he
 
     # ──────────────────────────────────────────────────────────────────
     def execute(
-        self, files: List[Path]
+        self, files: List[Path], rules: str | None = None
     ) -> Result[None, str]:  # noqa: D401 (simple verb)
         tree_result = self._repo.build_tree()
         if tree_result.is_err():
             return Err(tree_result.err())  # type: ignore[arg-type]
 
-        parts: List[str] = ["<tree_structure>", tree_result.ok(), "</tree_structure>"]  # type: ignore[list-item]
+        parts: List[str] = [
+            "<tree_structure>",
+            tree_result.ok(),
+            "</tree_structure>",
+        ]  # type: ignore[list-item]
+
+        if rules and rules.strip():
+            parts.extend([
+                "<rules_to_follow>",
+                rules.strip(),
+                "</rules_to_follow>",
+            ])
 
         for file_ in files:
             content_result = self._repo.read_file(file_)

--- a/application/copy_context.py
+++ b/application/copy_context.py
@@ -31,11 +31,13 @@ class CopyContextUseCase:  # noqa: D101 (public‑API docstring not mandatory he
         ]  # type: ignore[list-item]
 
         if rules and rules.strip():
-            parts.extend([
-                "<rules_to_follow>",
-                rules.strip(),
-                "</rules_to_follow>",
-            ])
+            parts.extend(
+                [
+                    "<rules_to_follow>",
+                    rules.strip(),
+                    "</rules_to_follow>",
+                ]
+            )
 
         for file_ in files:
             content_result = self._repo.read_file(file_)

--- a/application/copy_context.py
+++ b/application/copy_context.py
@@ -26,7 +26,7 @@ class CopyContextUseCase:  # noqa: D101 (public‑API docstring not mandatory he
 
         parts: List[str] = [
             "<tree_structure>",
-            tree_result.ok(),
+            tree_result.ok() or "",
             "</tree_structure>",
         ]  # type: ignore[list-item]
 
@@ -42,7 +42,7 @@ class CopyContextUseCase:  # noqa: D101 (public‑API docstring not mandatory he
             tag = f"<{file_}>"
             parts.append(tag)
             if content_result.is_ok():
-                parts.append(content_result.ok())  # type: ignore[list-item,arg-type]
+                parts.append(content_result.ok() or "")  # type: ignore[list-item,arg-type]
             # On failure, embed empty body — could embed error instead if desired.
             parts.append(f"</{file_}>")
 

--- a/application/ports.py
+++ b/application/ports.py
@@ -21,3 +21,9 @@ class DirectoryRepositoryPort(Protocol):
     def read_file(
         self, relative_path: Path
     ) -> Result[str, str]: ...  # pragma: no cover
+
+class RulesRepositoryPort(Protocol):
+    """Pure port for persisting / loading the user’s custom rules."""
+
+    def load_rules(self) -> Result[str, str]: ...      # pragma: no cover
+    def save_rules(self, rules: str) -> Result[None, str]: ...  # pragma: no cover

--- a/application/ports.py
+++ b/application/ports.py
@@ -22,8 +22,9 @@ class DirectoryRepositoryPort(Protocol):
         self, relative_path: Path
     ) -> Result[str, str]: ...  # pragma: no cover
 
+
 class RulesRepositoryPort(Protocol):
     """Pure port for persisting / loading the user’s custom rules."""
 
-    def load_rules(self) -> Result[str, str]: ...      # pragma: no cover
+    def load_rules(self) -> Result[str, str]: ...  # pragma: no cover
     def save_rules(self, rules: str) -> Result[None, str]: ...  # pragma: no cover

--- a/application/rules_service.py
+++ b/application/rules_service.py
@@ -24,4 +24,7 @@ class RulesService:  # noqa: D101
         if rules_result.is_err():
             # Propagate the domain-level validation error
             return Err(rules_result.err())  # type: ignore[arg-type]
-        return self._repo.save_rules(rules_result.ok().text())
+        rules = rules_result.ok()
+        if rules is None:
+            return Err("Failed to create rules object.")
+        return self._repo.save_rules(rules.text())

--- a/application/rules_service.py
+++ b/application/rules_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Final
+
+from domain.result import Result, Err, Ok
+from domain.rules import Rules
+from .ports import RulesRepositoryPort
+
+
+class RulesService:  # noqa: D101
+    __slots__ = ("_repo",)
+
+    def __init__(self, repo: RulesRepositoryPort):
+        self._repo: Final = repo
+
+    # -------------------------------------------------------------- queries
+    def load_rules(self) -> Result[str, str]:
+        """Load persisted rules text (may return Err if absent or unreadable)."""
+        return self._repo.load_rules()
+
+    # -------------------------------------------------------------- commands
+    def save_rules(self, raw_text: str) -> Result[None, str]:
+        rules_result = Rules.try_create(raw_text)
+        if rules_result.is_err():
+            # Propagate the domain-level validation error
+            return Err(rules_result.err())  # type: ignore[arg-type]
+        return self._repo.save_rules(rules_result.ok().text())

--- a/domain/rules.py
+++ b/domain/rules.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing_extensions import final
+
+from .result import Result, Ok, Err
+from .value_object import ValueObject
+
+
+@final
+class Rules(ValueObject):
+    """
+    Immutable wrapper around the raw rules text.
+
+    Construction goes through ``try_create`` so that illegal
+    states (empty text) are unrepresentable.
+    """
+
+    __slots__ = ("_text",)
+    _text: str
+
+    # ----------------------------------------------------------------- factory
+    @staticmethod
+    def try_create(text: str) -> Result["Rules", str]:
+        trimmed = text.strip()
+        return (
+            Err("Rules text cannot be empty.") if not trimmed else Ok(Rules(trimmed))
+        )
+
+    # ----------------------------------------------------------------- ctor (kept private – do not call directly)
+    def __init__(self, text: str):
+        self._text = text
+
+    # ----------------------------------------------------------------- accessors
+    def text(self) -> str:  # noqa: D401
+        return self._text

--- a/domain/rules.py
+++ b/domain/rules.py
@@ -22,9 +22,7 @@ class Rules(ValueObject):
     @staticmethod
     def try_create(text: str) -> Result["Rules", str]:
         trimmed = text.strip()
-        return (
-            Err("Rules text cannot be empty.") if not trimmed else Ok(Rules(trimmed))
-        )
+        return Err("Rules text cannot be empty.") if not trimmed else Ok(Rules(trimmed))
 
     # ----------------------------------------------------------------- ctor (kept private – do not call directly)
     def __init__(self, text: str):

--- a/domain/rules.py
+++ b/domain/rules.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing_extensions import final
 
+from domain.value_object import ValueObject
+
 from .result import Result, Ok, Err
-from .value_object import ValueObject
 
 
-@final
 class Rules(ValueObject):
     """
     Immutable wrapper around the raw rules text.

--- a/domain/value_object.py
+++ b/domain/value_object.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing_extensions import final
 
 
-
 class ValueObject:
     """Base class for immutable value objects compared *by value*."""
 

--- a/domain/value_object.py
+++ b/domain/value_object.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing_extensions import final
 
 
-@final
+
 class ValueObject:
     """Base class for immutable value objects compared *by value*."""
 

--- a/infrastructure/filesystem_rules_repository.py
+++ b/infrastructure/filesystem_rules_repository.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final
+
+from domain.result import Result, Ok, Err
+from application.ports import RulesRepositoryPort
+
+
+class FileSystemRulesRepository(RulesRepositoryPort):
+    """Reads / writes the rules text in the user’s home directory."""
+
+    __slots__ = ("_path",)
+
+    def __init__(self, path: Path | None = None):
+        default_path = Path.home() / ".copy_to_llm" / "rules"
+        self._path: Final = path or default_path
+
+    # -------------------------------------------------------------- public API
+    def load_rules(self) -> Result[str, str]:
+        try:  # I/O happens in infra, so a *try* is acceptable here
+            if not self._path.exists():
+                return Err("Rules file not found.")
+            raw = self._path.read_text(encoding="utf-8", errors="ignore")
+            return Ok(raw)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))
+
+    def save_rules(self, rules: str) -> Result[None, str]:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(rules, encoding="utf-8")
+            return Ok(None)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))

--- a/interface/gui.py
+++ b/interface/gui.py
@@ -28,7 +28,7 @@ from PySide6.QtWidgets import (
     QSizePolicy,
     QMenu,
     QToolButton,
-    QTextEdit
+    QTextEdit,
 )
 
 from application.copy_context import CopyContextUseCase
@@ -117,8 +117,7 @@ class RulesDialog(QDialog):
         self._edit.setPlainText(current_rules)
         layout.addWidget(self._edit)
         buttons = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok
-            | QDialogButtonBox.StandardButton.Cancel
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
         buttons.accepted.connect(self.accept)  # type: ignore[arg-type]
         buttons.rejected.connect(self.reject)  # type: ignore[arg-type]
@@ -217,7 +216,9 @@ class MainWindow(QMainWindow):
         toolbar.addWidget(spacer)
 
         # Settings dropdown with cog icon
-        settings_icon = self.style().standardIcon(self.style().StandardPixmap.SP_FileDialogDetailedView)
+        settings_icon = self.style().standardIcon(
+            self.style().StandardPixmap.SP_FileDialogDetailedView
+        )
         settings_menu = QMenu(self)
         edit_rules_action = QAction("Edit Rules", self)
         edit_rules_action.triggered.connect(self._open_settings)  # type: ignore[arg-type]
@@ -258,10 +259,10 @@ class MainWindow(QMainWindow):
             self._file_list.takeItem(row)
 
     def _open_settings(self) -> None:
-        result_load_rules: Result[str,str] = self._rules_service.load_rules()
+        result_load_rules: Result[str, str] = self._rules_service.load_rules()
         if result_load_rules.is_ok():
-            dialog = RulesDialog(result_load_rules.ok() or "",self._rules_service)
+            dialog = RulesDialog(result_load_rules.ok() or "", self._rules_service)
         else:
-            dialog = RulesDialog("",self._rules_service)
+            dialog = RulesDialog("", self._rules_service)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             self._rules = dialog.text()

--- a/interface/gui.py
+++ b/interface/gui.py
@@ -213,7 +213,7 @@ class MainWindow(QMainWindow):
 
         # Add spacer to push settings cog to the right
         spacer = QWidget()
-        spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         toolbar.addWidget(spacer)
 
         # Settings dropdown with cog icon
@@ -225,15 +225,11 @@ class MainWindow(QMainWindow):
         settings_button = QToolButton(self)
         settings_button.setIcon(settings_icon)
         settings_button.setMenu(settings_menu)
-        settings_button.setPopupMode(QToolButton.InstantPopup)
+        settings_button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         settings_button.setToolTip("Settings")
         toolbar.addWidget(settings_button)
 
     # ──────────────────────────────────────────────────────────────────
-
-    def _persist_rules(self) -> None:
-        current_rules = self.rules_edit.toPlainText()
-        self._rules_service.save_rules(current_rules)
 
     def _choose_directory(self):  # noqa: D401 (simple verb)
         directory = QFileDialog.getExistingDirectory(self, "Select Directory")
@@ -264,7 +260,7 @@ class MainWindow(QMainWindow):
     def _open_settings(self) -> None:
         result_load_rules: Result[str,str] = self._rules_service.load_rules()
         if result_load_rules.is_ok():
-            dialog = RulesDialog(result_load_rules.ok(),self._rules_service)
+            dialog = RulesDialog(result_load_rules.ok() or "",self._rules_service)
         else:
             dialog = RulesDialog("",self._rules_service)
         if dialog.exec() == QDialog.DialogCode.Accepted:

--- a/main.py
+++ b/main.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from PySide6.QtWidgets import QApplication
 
 from application.ports import ClipboardPort, DirectoryRepositoryPort
+from application.rules_service import RulesService
 from infrastructure.filesystem_directory_repository import FileSystemDirectoryRepository
+from infrastructure.filesystem_rules_repository import FileSystemRulesRepository
 from infrastructure.qt_clipboard_service import QtClipboardService
 from interface.gui import MainWindow
 
@@ -16,9 +18,11 @@ def main() -> None:  # noqa: D401 (simple verb)
 
     root = Path.cwd()
     repo: DirectoryRepositoryPort = FileSystemDirectoryRepository(root)
+    rules_repo = FileSystemRulesRepository()
+    rules_service = RulesService(rules_repo)
     clipboard: ClipboardPort = QtClipboardService()
 
-    window = MainWindow(repo, clipboard, root)
+    window = MainWindow(repo, clipboard, root,rules_service)
     window.show()
     sys.exit(app.exec())
 

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def main() -> None:  # noqa: D401 (simple verb)
     rules_service = RulesService(rules_repo)
     clipboard: ClipboardPort = QtClipboardService()
 
-    window = MainWindow(repo, clipboard, root,rules_service)
+    window = MainWindow(repo, clipboard, root, rules_service)
     window.show()
     sys.exit(app.exec())
 


### PR DESCRIPTION
## Summary
- support optional rules when copying context
- provide RulesDialog to edit rules in UI
- add Settings toolbar action
- include rules in clipboard as `<rules_to_follow>`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68496264525c8332b5d526e53cde4e07