### PR TITLE
Add clipboard notes field

### DIFF
--- a/application/copy_context.py
+++ b/application/copy_context.py
@@ -18,7 +18,9 @@ class CopyContextUseCase:  # noqa: D101 (public‑API docstring not mandatory he
 
     # ──────────────────────────────────────────────────────────────────
     def execute(
-        self, files: List[Path]
+        self,
+        files: List[Path],
+        user_text: str | None = None,
     ) -> Result[None, str]:  # noqa: D401 (simple verb)
         tree_result = self._repo.build_tree()
         if tree_result.is_err():
@@ -34,6 +36,11 @@ class CopyContextUseCase:  # noqa: D101 (public‑API docstring not mandatory he
                 parts.append(content_result.ok())  # type: ignore[list-item,arg-type]
             # On failure, embed empty body — could embed error instead if desired.
             parts.append(f"</{file_}>")
+
+        if user_text:
+            parts.append("<user_notes>")
+            parts.append(user_text)
+            parts.append("</user_notes>")
 
         self._clipboard.set_text(os.linesep.join(parts))
         return Ok(None)

--- a/interface/gui.py
+++ b/interface/gui.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
     QListWidgetItem,
     QMainWindow,
     QMessageBox,
+    QPlainTextEdit,
     QPushButton,
     QSplitter,
     QToolBar,
@@ -106,6 +107,7 @@ class MainWindow(QMainWindow):
         "_repo",
         "_clipboard",
         "_copy_context_use_case",
+        "_text_edit",
     )
 
     def __init__(
@@ -143,6 +145,10 @@ class MainWindow(QMainWindow):
         central = QWidget()
         layout = QVBoxLayout(central)
         layout.addWidget(splitter)
+        self._text_edit = QPlainTextEdit()
+        self._text_edit.setPlaceholderText("Describe your need or the bug here...")
+        self._text_edit.setFixedHeight(100)
+        layout.addWidget(self._text_edit)
         self.setCentralWidget(central)
 
         # --------------------------- toolbar
@@ -182,9 +188,10 @@ class MainWindow(QMainWindow):
             Path(item.text())
             for item in self._file_list.findItems("*", Qt.MatchFlag.MatchWildcard)
         ]
-        result = self._copy_context_use_case.execute(files)
+        user_text = self._text_edit.toPlainText().strip()
+        result = self._copy_context_use_case.execute(files, user_text or None)
         if result.is_err():
-            QMessageBox.critical(self, "Copy Context Error", result.err())
+            QMessageBox.critical(self, "Copy\u00A0Context\u00A0Error", result.err())
 
     def _delete_selected(self) -> None:
         for item in self._file_list.selectedItems():

--- a/tests/test_directory_tree.py
+++ b/tests/test_directory_tree.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from domain.directory_tree import build_tree
 from domain.result import Ok


### PR DESCRIPTION
## Summary
- add optional user text to `CopyContextUseCase`
- update `MainWindow` to show a bottom `QPlainTextEdit` for notes
- include notes in the copied context
- fix tests to run without installing the package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684961c6514083329f5e904f498511c5