### PR TITLE
Add recent repository history

### DIFF
--- a/application/ports.py
+++ b/application/ports.py
@@ -28,3 +28,12 @@ class RulesRepositoryPort(Protocol):
 
     def load_rules(self) -> Result[str, str]: ...  # pragma: no cover
     def save_rules(self, rules: str) -> Result[None, str]: ...  # pragma: no cover
+
+
+class RecentRepositoryPort(Protocol):
+    """Pure port for persisting recently opened repository paths."""
+
+    def load_paths(self) -> Result[list[Path], str]: ...  # pragma: no cover
+    def save_paths(
+        self, paths: list[Path]
+    ) -> Result[None, str]: ...  # pragma: no cover

--- a/application/recent_repository_service.py
+++ b/application/recent_repository_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final, List
+
+from domain.result import Result, Ok, Err
+from domain.recent_repositories import RecentRepositories
+from .ports import RecentRepositoryPort
+
+
+class RecentRepositoryService:  # noqa: D101
+    __slots__ = ("_repo",)
+
+    def __init__(self, repo: RecentRepositoryPort) -> None:
+        self._repo: Final = repo
+
+    # -------------------------------------------------------------- queries
+    def load_recent(self) -> Result[List[Path], str]:
+        return self._repo.load_paths()
+
+    # -------------------------------------------------------------- commands
+    def add_path(self, path: Path) -> Result[None, str]:
+        current_result = self._repo.load_paths()
+        if current_result.is_ok():
+            history_result = RecentRepositories.try_create(current_result.ok() or [])
+        else:
+            history_result = RecentRepositories.try_create([])
+        history = history_result.ok()
+        if history is None:
+            return Err("Failed to load history")
+        updated = history.add(path)
+        return self._repo.save_paths(list(updated.paths()))

--- a/domain/recent_repositories.py
+++ b/domain/recent_repositories.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Tuple, Final
+
+from typing_extensions import final
+
+from .value_object import ValueObject
+from .result import Result, Ok, Err
+
+MAX_HISTORY: Final[int] = 10
+
+
+@final
+class RecentRepositories(ValueObject):
+    """Immutable list of recently opened repository paths."""
+
+    __slots__ = ("_paths",)
+    _paths: Tuple[Path, ...]
+
+    # --------------------------------------------------------------------- factory
+    @staticmethod
+    def try_create(paths: Iterable[Path]) -> Result["RecentRepositories", str]:
+        unique: List[Path] = []
+        for path in paths:
+            if path not in unique:
+                unique.append(path)
+        if len(unique) > MAX_HISTORY:
+            unique = unique[:MAX_HISTORY]
+        return Ok(RecentRepositories(tuple(unique)))
+
+    # --------------------------------------------------------------------- ctor
+    def __init__(self, paths: Tuple[Path, ...]):
+        self._paths = paths
+
+    # --------------------------------------------------------------------- accessors
+    def paths(self) -> Tuple[Path, ...]:  # noqa: D401
+        return self._paths
+
+    # --------------------------------------------------------------------- operations
+    def add(self, path: Path) -> "RecentRepositories":
+        """Return a new object with ``path`` added to the history."""
+        new_paths = [p for p in self._paths if p != path]
+        new_paths.insert(0, path)
+        if len(new_paths) > MAX_HISTORY:
+            new_paths = new_paths[:MAX_HISTORY]
+        return RecentRepositories(tuple(new_paths))

--- a/infrastructure/filesystem_recent_repository.py
+++ b/infrastructure/filesystem_recent_repository.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Final, List
+
+from domain.result import Result, Ok, Err
+from application.ports import RecentRepositoryPort
+
+
+class FileSystemRecentRepository(RecentRepositoryPort):
+    """Persists the list of recently opened repositories on disk."""
+
+    __slots__ = ("_path",)
+
+    def __init__(self, path: Path | None = None) -> None:
+        default_path = Path.home() / ".copy_to_llm" / "recent_repos"
+        self._path: Final = path or default_path
+
+    def load_paths(self) -> Result[List[Path], str]:  # noqa: D401
+        try:
+            if not self._path.exists():
+                return Ok([])
+            raw = self._path.read_text(encoding="utf-8", errors="ignore")
+            lines = [Path(line) for line in raw.splitlines() if line.strip()]
+            return Ok(lines)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))
+
+    def save_paths(self, paths: List[Path]) -> Result[None, str]:  # noqa: D401
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            content = "\n".join(str(p) for p in paths)
+            self._path.write_text(content, encoding="utf-8")
+            return Ok(None)
+        except Exception as exc:  # noqa: BLE001
+            return Err(str(exc))

--- a/main.py
+++ b/main.py
@@ -7,8 +7,10 @@ from PySide6.QtWidgets import QApplication
 
 from application.ports import ClipboardPort, DirectoryRepositoryPort
 from application.rules_service import RulesService
+from application.recent_repository_service import RecentRepositoryService
 from infrastructure.filesystem_directory_repository import FileSystemDirectoryRepository
 from infrastructure.filesystem_rules_repository import FileSystemRulesRepository
+from infrastructure.filesystem_recent_repository import FileSystemRecentRepository
 from infrastructure.qt_clipboard_service import QtClipboardService
 from interface.gui import MainWindow
 
@@ -20,9 +22,17 @@ def main() -> None:  # noqa: D401 (simple verb)
     repo: DirectoryRepositoryPort = FileSystemDirectoryRepository(root)
     rules_repo = FileSystemRulesRepository()
     rules_service = RulesService(rules_repo)
+    recent_repo = FileSystemRecentRepository()
+    recent_service = RecentRepositoryService(recent_repo)
     clipboard: ClipboardPort = QtClipboardService()
 
-    window = MainWindow(repo, clipboard, root, rules_service)
+    window = MainWindow(
+        repo,
+        clipboard,
+        root,
+        rules_service,
+        recent_service,
+    )
     window.show()
     sys.exit(app.exec())
 


### PR DESCRIPTION
## Summary
- track recently opened repositories on disk
- expose recent repository service and port
- add recent repository history to GUI toolbar
- persist selection from main entry point

## Testing
- `black --check .`
- `mypy .` *(fails: Cannot find implementation or library stub for PySide6)*
- `pytest -q`
- `behave` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498389a3f08332a59b1234dc957d8d