### PR TITLE
Add tree context toggle

### DIFF
--- a/application/copy_context.py
+++ b/application/copy_context.py
@@ -22,16 +22,22 @@ class CopyContextUseCase:  # noqa: D101 (public‑API docstring not mandatory he
         files: List[Path],
         rules: str | None = None,
         user_request: str | None = None,
+        include_tree: bool = True,
     ) -> Result[None, str]:  # noqa: D401 (simple verb)
-        tree_result = self._repo.build_tree()
-        if tree_result.is_err():
-            return Err(tree_result.err())  # type: ignore[arg-type]
+        parts: List[str] = []
 
-        parts: List[str] = [
-            "<tree_structure>",
-            tree_result.ok() or "",
-            "</tree_structure>",
-        ]  # type: ignore[list-item]
+        if include_tree:
+            tree_result = self._repo.build_tree()
+            if tree_result.is_err():
+                return Err(tree_result.err())  # type: ignore[arg-type]
+
+            parts.extend(
+                [
+                    "<tree_structure>",
+                    tree_result.ok() or "",
+                    "</tree_structure>",
+                ]
+            )
 
         for file_ in files:
             content_result = self._repo.read_file(file_)

--- a/interface/gui.py
+++ b/interface/gui.py
@@ -174,6 +174,7 @@ class MainWindow(QMainWindow):
         "user_request_text_edit",
         "_rules",
         "_include_rules_checkbox",
+        "_include_tree_checkbox",
     )
 
     def __init__(
@@ -269,6 +270,8 @@ class MainWindow(QMainWindow):
 
         # --------------------------- bottom bar for copy context button
         bottom_bar_layout = QHBoxLayout()
+        self._include_tree_checkbox = QCheckBox("Include Tree Context")
+        self._include_tree_checkbox.setChecked(True)
         self._include_rules_checkbox = QCheckBox("Include Rules")
         self._include_rules_checkbox.setChecked(True)
         # Copy context button
@@ -277,6 +280,7 @@ class MainWindow(QMainWindow):
         delete_btn = QPushButton("Delete Selected")
         delete_btn.clicked.connect(self._delete_selected)  # type: ignore[arg-type]
         # Bottom bar layout for "Copy Context" button
+        bottom_bar_layout.addWidget(self._include_tree_checkbox)
         bottom_bar_layout.addWidget(self._include_rules_checkbox)
         bottom_bar_layout.addStretch(1)  # Pushes everything else to the right
         bottom_bar_layout.addWidget(delete_btn)
@@ -338,7 +342,10 @@ class MainWindow(QMainWindow):
         ]
         user_text = self.user_request_text_edit.toPlainText().strip()
         rules_text = self._rules if self._include_rules_checkbox.isChecked() else None
-        result = self._copy_context_use_case.execute(files, rules_text, user_text)
+        include_tree = self._include_tree_checkbox.isChecked()
+        result = self._copy_context_use_case.execute(
+            files, rules_text, user_text, include_tree
+        )
 
         if result.is_err():
             QMessageBox.critical(self, "Copy\u00a0Context\u00a0Error", result.err())

--- a/tests/test_copy_context.py
+++ b/tests/test_copy_context.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from application.copy_context import CopyContextUseCase
+from infrastructure.filesystem_directory_repository import FileSystemDirectoryRepository
+
+
+class FakeClipboard:
+    def __init__(self) -> None:
+        self.text: str | None = None
+
+    def set_text(self, text: str) -> None:
+        self.text = text
+
+
+def test_include_tree_flag(tmp_path: Path):
+    (tmp_path / "file.txt").write_text("hello")
+    repo = FileSystemDirectoryRepository(tmp_path)
+    clipboard = FakeClipboard()
+    use_case = CopyContextUseCase(repo, clipboard)
+    use_case.execute([], include_tree=True)
+    assert "<tree_structure>" in clipboard.text
+    clipboard2 = FakeClipboard()
+    use_case2 = CopyContextUseCase(repo, clipboard2)
+    use_case2.execute([], include_tree=False)
+    assert clipboard2.text is not None
+    assert "<tree_structure>" not in clipboard2.text

--- a/tests/test_copy_context.py
+++ b/tests/test_copy_context.py
@@ -22,6 +22,7 @@ def test_include_tree_flag(tmp_path: Path):
     clipboard = FakeClipboard()
     use_case = CopyContextUseCase(repo, clipboard)
     use_case.execute([], include_tree=True)
+    assert clipboard.text is not None
     assert "<tree_structure>" in clipboard.text
     clipboard2 = FakeClipboard()
     use_case2 = CopyContextUseCase(repo, clipboard2)


### PR DESCRIPTION
## Summary
- add optional `include_tree` parameter in `CopyContextUseCase`
- expose "Include Tree Context" checkbox in GUI
- update `_copy_context` invocation
- test copy context tree toggle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684987327c648332a9a59faa7366debe