### PR TITLE
Enable monthly dependency updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Summary
- configure dependabot for monthly updates of Python and GitHub Actions dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c473c10f08332b921cea0f02fbd09