### PR TITLE
Improve layout of context buffer buttons

### DIFF
--- a/UserManual.md
+++ b/UserManual.md
@@ -13,7 +13,7 @@
    - Enable or disable specific **rules**.
    - Add your **task description** in the input field.
    - Choose whether to **include the directory tree**.
-5. Click **"Copy Context in clipboard"**.
+5. Click **"Copy Context"**.
 6. **Paste the result into your LLM tool** to get coding assistance.
 
 ---
@@ -27,7 +27,7 @@
 | **Context Buffer**     | Shows selected files and snippets to be included in the context. Supports drag & drop.          |
 | **User Request Box**   | Optional field to describe the bug, feature request, or prompt to the LLM.                      |
 | **Rules Selection**    | Check rules you'd like to include. Click ⚙️ to edit or create rules.                             |
-| **Bottom Bar Buttons** | Copy context or delete selected items from the buffer.                                           |
+| **Context Buffer Actions** | Use the buttons at the top-right of the buffer to delete items or copy the context. |
 
 ---
 

--- a/src/codebase_to_llm/interface/main_window.py
+++ b/src/codebase_to_llm/interface/main_window.py
@@ -178,7 +178,27 @@ class MainWindow(QMainWindow):
         buffer_title.setToolTip(
             "Files and text snippets that will be included in the context. Drag files from the directory tree to add them here."
         )
-        right_layout.addWidget(buffer_title)
+
+        copy_icon = self.style().standardIcon(self.style().StandardPixmap.SP_DialogApplyButton)
+        copy_btn = QPushButton("Copy Context")
+        copy_btn.setIcon(copy_icon)
+        copy_btn.setIconSize(QSize(24, 24))
+        copy_btn.setMinimumHeight(30)
+        copy_btn.clicked.connect(self._copy_context)  # type: ignore[arg-type]
+
+        delete_icon = self.style().standardIcon(self.style().StandardPixmap.SP_TrashIcon)
+        delete_btn = QPushButton("Delete Selected")
+        delete_btn.setIcon(delete_icon)
+        delete_btn.setIconSize(QSize(24, 24))
+        delete_btn.setMinimumHeight(30)
+        delete_btn.clicked.connect(self._delete_selected)  # type: ignore[arg-type]
+
+        title_bar_layout = QHBoxLayout()
+        title_bar_layout.addWidget(buffer_title)
+        title_bar_layout.addStretch(1)
+        title_bar_layout.addWidget(delete_btn)
+        title_bar_layout.addWidget(copy_btn)
+        right_layout.addLayout(title_bar_layout)
 
         self._file_list = ContextBufferWidget(initial_root, self._copy_context)
         right_layout.addWidget(self._file_list)
@@ -260,15 +280,9 @@ class MainWindow(QMainWindow):
         self._rules_button.setMenu(self._rules_menu)
         self._rules_button.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         self._refresh_rules_checkboxes()
-        copy_btn = QPushButton("Copy Context in clipboard")
-        copy_btn.clicked.connect(self._copy_context)  # type: ignore[arg-type]
-        delete_btn = QPushButton("Delete Selected")
-        delete_btn.clicked.connect(self._delete_selected)  # type: ignore[arg-type]
         bottom_bar_layout.addWidget(self._include_tree_checkbox)
         bottom_bar_layout.addWidget(self._rules_button)
         bottom_bar_layout.addStretch(1)
-        bottom_bar_layout.addWidget(delete_btn)
-        bottom_bar_layout.addWidget(copy_btn)
 
         layout.addLayout(bottom_bar_layout)
 

--- a/src/codebase_to_llm/interface/main_window.py
+++ b/src/codebase_to_llm/interface/main_window.py
@@ -179,14 +179,18 @@ class MainWindow(QMainWindow):
             "Files and text snippets that will be included in the context. Drag files from the directory tree to add them here."
         )
 
-        copy_icon = self.style().standardIcon(self.style().StandardPixmap.SP_DialogApplyButton)
+        copy_icon = self.style().standardIcon(
+            self.style().StandardPixmap.SP_DialogApplyButton
+        )
         copy_btn = QPushButton("Copy Context")
         copy_btn.setIcon(copy_icon)
         copy_btn.setIconSize(QSize(24, 24))
         copy_btn.setMinimumHeight(30)
         copy_btn.clicked.connect(self._copy_context)  # type: ignore[arg-type]
 
-        delete_icon = self.style().standardIcon(self.style().StandardPixmap.SP_TrashIcon)
+        delete_icon = self.style().standardIcon(
+            self.style().StandardPixmap.SP_TrashIcon
+        )
         delete_btn = QPushButton("Delete Selected")
         delete_btn.setIcon(delete_icon)
         delete_btn.setIconSize(QSize(24, 24))


### PR DESCRIPTION
## Summary
- move Copy/Delete buttons to top-right of Context Buffer
- add icons and larger size for touch interaction
- update user manual to reflect new location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850138a68d88332afd17a56799047bc